### PR TITLE
docs: Fix simple typo, instanciate -> instantiate

### DIFF
--- a/static/autocomplete_light/autocomplete.js
+++ b/static/autocomplete_light/autocomplete.js
@@ -243,7 +243,7 @@ yourlabs.Autocomplete = function (input) {
 Rather than directly setting up the autocomplete (DOM events etc ...) in
 the constructor, setup is done in this method. This allows to:
 
-- instanciate an Autocomplete,
+- instantiate an Autocomplete,
 - override attribute/methods of the instance,
 - and *then* setup the instance.
  */

--- a/static/autocomplete_light/widget.js
+++ b/static/autocomplete_light/widget.js
@@ -278,7 +278,7 @@ yourlabs.Widget.prototype.destroy = function(widget) {
 
 // Get or create or destroy a widget instance.
 //
-// On first call, yourlabsWidget() will instanciate a widget applying all
+// On first call, yourlabsWidget() will instantiate a widget applying all
 // passed overrides.
 // 
 // On later calls, yourlabsWidget() will return the previously created widget


### PR DESCRIPTION
There is a small typo in static/autocomplete_light/autocomplete.js, static/autocomplete_light/widget.js.

Should read `instantiate` rather than `instanciate`.

